### PR TITLE
参照カウント管理を改善し、エラー時にイテレータと次のオブジェクトを適切に解放するよう修正。

### DIFF
--- a/libgeonlp/pygeonlp.cpp
+++ b/libgeonlp/pygeonlp.cpp
@@ -267,11 +267,15 @@ static PyObject * geonlp_ma_set_active_dictionaries(GeonlpMA *self, PyObject *ar
     PyObject *next = PyIter_Next(iter);
     if (!next) break;
     if (!PyLong_Check(next)) {
+      Py_DECREF(next);
+      Py_DECREF(iter);
       PyErr_SetString(PyExc_TypeError, "Param must be a list of int values.");
       return NULL;
     }
     dic_ids.push_back(int(PyLong_AsLong(next)));
+    Py_DECREF(next);
   }
+  Py_DECREF(iter);
   (self->_ptrObj)->setActiveDictionaries(dic_ids);
   Py_INCREF(Py_None);
   return Py_None;
@@ -314,7 +318,9 @@ static PyObject * geonlp_ma_set_active_classes(GeonlpMA *self, PyObject *args)
     } else if (PyUnicode_Check(next)) {
       ne_classes.push_back(std::string(PyUnicode_AsUTF8AndSize(next, NULL)));
     }
+    Py_DECREF(next);
   }
+  Py_DECREF(iter);
   (self->_ptrObj)->setActiveClasses(ne_classes);
   Py_INCREF(Py_None);
   return Py_None;


### PR DESCRIPTION
メモリリークをしていると思われる箇所の対応を実施致しました。

- 各種情報
  - pythonバージョン
    - 3.13.7
  - pygeonlpのバージョン
    - v1.2.4.post1

下記のように簡易的ではありますが、スクリプトを作成しました。

<details>

<summary>簡易スクリプト</summary>

```
import os
import psutil
import pygeonlp.api as api

process = psutil.Process(os.getpid())
api.init(db_dir='/app/mydic', jageocoder=False)

def main():
    text = "私は昨日飯田橋にいました。"

    for i in range(100001):
        if i % 10000 == 0:
            print(f'loop: {i} memory usage: {process.memory_info().rss / 1024 / 1024} MB')

        # メモリリークを再現するため、setActiveDictionariesとsetActiveClassesを呼び出す
        api.setActiveDictionaries(pattern=r'.*')
        api.setActiveClasses(['.*'])
        api.geoparse(text)


if __name__ == "__main__":
    main()
```

</details>

`v1.2.4.post1` を使った場合は下記のようになりました。

```
root@516248a42df5:/app# python main.py
loop: 0 memory usage: 45.625 MB
loop: 10000 memory usage: 50.24609375 MB
loop: 20000 memory usage: 51.24609375 MB
loop: 30000 memory usage: 52.12109375 MB
loop: 40000 memory usage: 53.12109375 MB
loop: 50000 memory usage: 53.99609375 MB
loop: 60000 memory usage: 54.87109375 MB
loop: 70000 memory usage: 55.87109375 MB
loop: 80000 memory usage: 56.74609375 MB
loop: 90000 memory usage: 57.62109375 MB
loop: 100000 memory usage: 58.62109375 MB
```

修正した `pygeonlp` に差し替えて実行した場合は、下記のようになりました。
メモリ使用量が増えなくなったので、リークは解消したと考えています。

```
root@5562d5d147e0:/app# python main.py 
loop: 0 memory usage: 48.90234375 MB
loop: 10000 memory usage: 52.3984375 MB
loop: 20000 memory usage: 52.3984375 MB
loop: 30000 memory usage: 52.3984375 MB
loop: 40000 memory usage: 52.3984375 MB
loop: 50000 memory usage: 52.3984375 MB
loop: 60000 memory usage: 52.3984375 MB
loop: 70000 memory usage: 52.3984375 MB
loop: 80000 memory usage: 52.3984375 MB
loop: 90000 memory usage: 52.3984375 MB
loop: 100000 memory usage: 52.3984375 MB
```